### PR TITLE
Set default pins as QSPI_FLASH1_xxx instead NC

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -2,49 +2,25 @@
 "name": "qspif",
     "config": {
         "QSPI_FREQ": "40000000",
-        "QSPI_IO0": "NC",
-        "QSPI_IO1": "NC",
-        "QSPI_IO2": "NC",
-        "QSPI_IO3": "NC",
-        "QSPI_CLK": "NC",
-        "QSPI_CS": "NC"
+        "QSPI_IO0": "QSPI_FLASH1_IO0",
+        "QSPI_IO1": "QSPI_FLASH1_IO1",
+        "QSPI_IO2": "QSPI_FLASH1_IO2",
+        "QSPI_IO3": "QSPI_FLASH1_IO3",
+        "QSPI_CLK": "QSPI_FLASH1_SCK",
+        "QSPI_CS": "QSPI_FLASH1_CSN"
     },
     "target_overrides": {
         "DISCO_F413ZH": {
-             "QSPI_FREQ": "80000000",
-             "QSPI_IO0": "PF_8",
-             "QSPI_IO1": "PF_9",
-             "QSPI_IO2": "PE_2",
-             "QSPI_IO3": "PD_13",
-             "QSPI_CLK": "PB_2",
-             "QSPI_CS": "PG_6"
+             "QSPI_FREQ": "80000000"
         },
        "DISCO_L475VG_IOT01A": {
-             "QSPI_FREQ": "8000000",
-             "QSPI_IO0": "PE_12",
-             "QSPI_IO1": "PE_13",
-             "QSPI_IO2": "PE_14",
-             "QSPI_IO3": "PE_15",
-             "QSPI_CLK": "PE_10",
-             "QSPI_CS": "PE_11"
+             "QSPI_FREQ": "8000000"
         },
        "DISCO_L476VG": {
-             "QSPI_FREQ": "8000000",
-             "QSPI_IO0": "PE_12",
-             "QSPI_IO1": "PE_13",
-             "QSPI_IO2": "PE_14",
-             "QSPI_IO3": "PE_15",
-             "QSPI_CLK": "PE_10",
-             "QSPI_CS": "PE_11"
+             "QSPI_FREQ": "8000000"
         },
        "DISCO_F469NI": {
-             "QSPI_FREQ": "8000000",
-             "QSPI_IO0": "PF_8",
-             "QSPI_IO1": "PF_9",
-             "QSPI_IO2": "PF_7",
-             "QSPI_IO3": "PF_6",
-             "QSPI_CLK": "PF_10",
-             "QSPI_CS": "PB_6"
+             "QSPI_FREQ": "8000000"
         }
     }
 }


### PR DESCRIPTION
Changing as per the suggestion here https://github.com/ARMmbed/qspif-blockdevice/pull/13#issuecomment-419488888

CC @adbridge @stevew817